### PR TITLE
Send remote image_urls to OpenAI instead of image base64 data

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,8 @@
 OPENAI_API_KEY=sk-proj-your_key_here
 RUNPOD_API_KEY=get-from-https://www.runpod.io/console/user/settings
 RUNPOD_SERVERLESS_ID=get-from-https://www.runpod.io/console/serverless/user/endpoint/:id
+# Limit to AWS keys for accessing the specified S3, used for uploading assets
+S3_BUCKET_NAME=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 #.idea/
 
 .files
+tmp


### PR DESCRIPTION
## What

Upload each attached image first, then pass the presigned image_url instead of base64 data.

## Why

> For a real app, it's better to upload your images to a bucket somewhere, and pass the url to gpt4o. This allows them to cache the image.

> If we pass as base64 data, we have to pass the image with each chat message, since we send the entire chat conversation with each message.

## How

- Use boto3 and upload to S3
- It's then trivial to support multiple images in the same message

NOTE: it seems PDF attachment is not supported yet, so we would have to extract each PDF into images if we want to support PDF? (or change to use Assistant API?)